### PR TITLE
Fail builds by default if Unsuppressed CVEs are detected

### DIFF
--- a/src/integrationTest/groovy/uk/gov/hmcts/IntegrationTest.groovy
+++ b/src/integrationTest/groovy/uk/gov/hmcts/IntegrationTest.groovy
@@ -72,7 +72,7 @@ class IntegrationTest extends Specification {
         !(result.output =~ "Analyzing.+:compileOnly\\s")
     }
 
-    def "Dependency check can fail build"(args, buildResult) {
+    def "Dependency check fails build by default"() {
         given:
         buildFile << """
             plugins {
@@ -90,17 +90,12 @@ class IntegrationTest extends Specification {
         """
         when:
         // Expect build failure or success depending on provided Gradle property.
-        def result = runner((["dependencyCheckAnalyze"] + args) as String[])
-            ."$buildResult"()
+        def result = runner((["dependencyCheckAnalyze"]) as String[])
+            .buildAndFail()
 
         then:
         result.output.contains("dependencies were identified with known vulnerabilities")
         new File(projectFolder.getRoot(), 'build/reports/dependency-check-report.html').exists()
-
-        where:
-        args | buildResult
-        ["-DdependencyCheck.failBuild=true"] | "buildAndFail"
-        [] | "build"
     }
 
     def "Dependency check detects vulnerabilities in transient dependencies"() {
@@ -127,7 +122,7 @@ class IntegrationTest extends Specification {
         """
 
         when:
-        def result = runner((["dependencyCheckAnalyze"] + '-DdependencyCheck.failBuild=true') as String[])
+        def result = runner((["dependencyCheckAnalyze"]) as String[])
                 .buildAndFail()
 
         then:

--- a/src/main/java/uk/gov/hmcts/tools/DependencyCheckSetup.java
+++ b/src/main/java/uk/gov/hmcts/tools/DependencyCheckSetup.java
@@ -35,13 +35,8 @@ public final class DependencyCheckSetup {
     public static void apply(Project project) {
         project.getPlugins().apply(DependencyCheckPlugin.class);
 
-        // Specifies if the build should be failed if a CVSS score above a specified level is identified.
-        // range of 0-10 fails the build, anything greater and it doesn't fail the build.
-        int code = "true".equalsIgnoreCase(System.getProperty("dependencyCheck.failBuild"))
-            ? 0
-            : 11;
         DependencyCheckExtension extension = project.getExtensions().getByType(DependencyCheckExtension.class);
-        extension.setFailBuildOnCVSS((float) code);
+        extension.setFailBuildOnCVSS(0f);
 
         // Disable scanning of .NET related binaries
         extension.getAnalyzers().setAssemblyEnabled(false);


### PR DESCRIPTION
### Change description ###

Configure the OWASP dependency checker to fail on any unsuppressed CVEs, by default.

