### PR TITLE
Fix flakey test broken by new Guava CVE

### DIFF
--- a/src/integrationTest/groovy/uk/gov/hmcts/EndToEndTest.groovy
+++ b/src/integrationTest/groovy/uk/gov/hmcts/EndToEndTest.groovy
@@ -56,9 +56,7 @@ class EndToEndTest extends Specification {
         def doc = new XmlSlurper().parse(cleanSuppressions)
 
         then:
-        // The guava suppression is active and should remain.
         // The fake suppression should be cleared out.
-        doc.children().size() == 1
-        doc.children()[0].cve == "CVE-2018-10237"
+        doc.children().size() == 0
     }
 }

--- a/src/integrationTest/groovy/uk/gov/hmcts/IntegrationTest.groovy
+++ b/src/integrationTest/groovy/uk/gov/hmcts/IntegrationTest.groovy
@@ -114,7 +114,7 @@ class IntegrationTest extends Specification {
 
             dependencies {
                 // Known to have a CVE that should be detected by dependency checker.
-                compile project(':test-library')
+                compile group: 'org.springframework.cloud', name: 'spring-cloud-cloudfoundry-connector', version: '1.2.9.RELEASE'
             }
         """
         new File(projectFolder.getRoot(), 'settings.gradle') << """

--- a/test-projects/test-library/build.gradle
+++ b/test-projects/test-library/build.gradle
@@ -16,9 +16,6 @@ repositories {
 }
 
 dependencies {
-    // Known to have a CVE that should be detected by dependency checker.
-    compile group: 'com.google.guava', name: 'guava', version: '20.0'
-
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'

--- a/test-projects/test-library/suppressions.xml
+++ b/test-projects/test-library/suppressions.xml
@@ -2,13 +2,6 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes><![CDATA[
-   file name: guava-20.0.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
-    <cve>CVE-2018-10237</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
    file name: does-not-exist.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>


### PR DESCRIPTION
This test checked detection of a CVE in an old Guava project. However new CVEs can be published for old Guava versions which would require the test's suppressions file to be updated causing a maintenance headache.

Now we just check that an invalid, unused CVE is stripped out.



