### PR TITLE
Remove utility class constructor rule

### DIFF
--- a/src/main/resources/hmcts-checkstyle.xml
+++ b/src/main/resources/hmcts-checkstyle.xml
@@ -34,7 +34,6 @@
   </module>
   <module name="TreeWalker">
     <module name="UnusedImports"/>
-    <module name="HideUtilityClassConstructor"/>
     <module name="SuppressWarningsHolder" />
     <module name="OuterTypeFilename"/>
     <module name="IllegalTokenText">


### PR DESCRIPTION
### Change description ###

This rule adds boilerplate to all our spring boot application entry points, which spring requires to have a visible constructor.
