### PR TITLE
Support latest checkstyle version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,8 @@ gradlePlugin {
 
 sourceSets {
     integrationTest {
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
     }
 }
 

--- a/src/integrationTest/groovy/uk/gov/hmcts/EndToEndTest.groovy
+++ b/src/integrationTest/groovy/uk/gov/hmcts/EndToEndTest.groovy
@@ -6,6 +6,7 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import uk.gov.hmcts.tools.CheckstyleSetup
 
 // Test plugin against a complete Java library project.
 class EndToEndTest extends Specification {
@@ -33,6 +34,7 @@ class EndToEndTest extends Specification {
                 ":cleanSuppressions",
                 ":assertRepositoriesOrdered"
         )
+        result.output =~ "Running Checkstyle " + CheckstyleSetup.minCheckstyleVersion
 
         where:
         gradleVersion << [

--- a/src/main/java/uk/gov/hmcts/tools/CheckstyleSetup.java
+++ b/src/main/java/uk/gov/hmcts/tools/CheckstyleSetup.java
@@ -7,6 +7,7 @@ import org.gradle.api.plugins.quality.Checkstyle;
 import org.gradle.api.plugins.quality.CheckstyleExtension;
 import org.gradle.api.plugins.quality.CheckstylePlugin;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.util.VersionNumber;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -18,6 +19,7 @@ import javax.inject.Inject;
 public class CheckstyleSetup extends DefaultTask {
 
     File configFile;
+    public static final String minCheckstyleVersion = "10.3.1";
 
     public static void apply(Project project) {
         project.getPlugins().apply(CheckstylePlugin.class);
@@ -32,9 +34,13 @@ public class CheckstyleSetup extends DefaultTask {
 
             for (Checkstyle checkstyleTask : project.getTasks().withType(Checkstyle.class)) {
                 if (checkstyleTask.getConfigFile() == null || !checkstyleTask.getConfigFile().exists()) {
-                    // Only set the tool version if we set the config file, since
-                    // file format can be tied to checkstyle version.
-                    ext.setToolVersion("8.31");
+                    // If using bundled checkstyle config, set a floor for checkstyle version since older versions may
+                    // not support our bundled config.
+                    if (VersionNumber.parse(minCheckstyleVersion)
+                        .compareTo(VersionNumber.parse(ext.getToolVersion())) > 0) {
+                        ext.setToolVersion(minCheckstyleVersion);
+                    }
+
                     checkstyleTask.setConfigFile(writer.configFile);
                     checkstyleTask.dependsOn(writer);
                 }

--- a/src/main/resources/hmcts-checkstyle.xml
+++ b/src/main/resources/hmcts-checkstyle.xml
@@ -210,7 +210,6 @@
       <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
     <module name="JavadocMethod">
-      <property name="scope" value="nothing"/>
       <property name="allowMissingParamTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
       <property name="allowedAnnotations" value="Override, Test"/>

--- a/src/test/groovy/uk.gov.hmcts/Test.groovy
+++ b/src/test/groovy/uk.gov.hmcts/Test.groovy
@@ -1,8 +1,5 @@
 package uk.gov.hmcts
 
-import groovy.xml.XmlSlurper
-import groovy.xml.XmlUtil
-import org.w3c.dom.Element
 import spock.lang.Specification
 import uk.gov.hmcts.tools.DependencyCheckSetup
 


### PR DESCRIPTION
### Change description ###

And set it as a floor for the checkstyle version when using the bundled styleguide; this is to ensure that older versions of Gradle (which use old checkstyle versions) will work correctly with the bundled styleguide.

