### PR TITLE
Use production runtime classpath for dependency checks

### DIFF
--- a/src/main/java/uk/gov/hmcts/tools/DependencyCheckSetup.java
+++ b/src/main/java/uk/gov/hmcts/tools/DependencyCheckSetup.java
@@ -29,6 +29,8 @@ import org.w3c.dom.NodeList;
 
 public final class DependencyCheckSetup {
 
+    private static final String PRODUCTION_RUNTIME_CLASSPATH = "productionRuntimeClasspath";
+
     private DependencyCheckSetup() {
     }
 
@@ -69,7 +71,7 @@ public final class DependencyCheckSetup {
 
         // Scan only runtime configurations by default.
         // This can be overridden in project build script if desired.
-        extension.getScanConfigurations().add("runtimeClasspath");
+        extension.getScanConfigurations().add(PRODUCTION_RUNTIME_CLASSPATH);
 
         extension.getFormats().add(Format.XML.name());
         Task cleaner = project.getTasks().create("cleanSuppressions");

--- a/src/test/groovy/uk.gov.hmcts/Test.groovy
+++ b/src/test/groovy/uk.gov.hmcts/Test.groovy
@@ -1,9 +1,25 @@
 package uk.gov.hmcts
 
+import org.gradle.testfixtures.ProjectBuilder
+import org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension
 import spock.lang.Specification
+import uk.gov.hmcts.JavaPlugin
 import uk.gov.hmcts.tools.DependencyCheckSetup
 
 class Test extends Specification {
+
+    def "configures dependency check to scan production runtime classpath"() {
+        given:
+        def project = ProjectBuilder.builder().build()
+
+        when:
+        project.plugins.apply(JavaPlugin)
+        def extension = project.extensions.getByType(DependencyCheckExtension)
+
+        then:
+        extension.scanConfigurations.get() == ["productionRuntimeClasspath"]
+        extension.skipTestGroups.get()
+    }
 
     def "extracts set of CVEs from suppression report"() {
         given:


### PR DESCRIPTION
Dependency Check was scanning `runtimeClasspath`, which can be skipped by OWASP dependency-check when Spring Boot adds `testAndDevelopmentOnly` to the hierarchy.

Switch to `productionRuntimeClasspath`, which is what Boot packages for production.

Upstream context:
https://github.com/dependency-check/dependency-check-gradle/issues/410
https://github.com/dependency-check/dependency-check-gradle/issues/410#issuecomment-2379321531

Tested with `./gradlew test --info` and a local `ccd-data-store-api` dependency-check run.
